### PR TITLE
Prepare a new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,16 +300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "executor-macros"
-version = "0.1.0"
-source = "git+https://github.com/kaimast/tokio-uring-executor.git#9f999ed52803a86ae4d3a3a21afef91232323bec"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +487,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "kioto-uring-executor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524055a91bab4a6567a543f04bb7ea6e75ba7f9642c072eeeed8b64e5224e62"
+dependencies = [
+ "kioto-uring-executor-macros",
+ "log",
+ "rand",
+ "tokio",
+ "tokio-uring",
+]
+
+[[package]]
+name = "kioto-uring-executor-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87826da5a57e29aa65d7cc5929629ec70705ad4ec9d6d9ca9625aa5c903b7c51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +578,7 @@ dependencies = [
  "csv",
  "env_logger",
  "futures",
+ "kioto-uring-executor",
  "log",
  "lru",
  "memmap2",
@@ -573,7 +588,6 @@ dependencies = [
  "tokio",
  "tokio-condvar",
  "tokio-uring",
- "tokio-uring-executor",
  "tracing",
  "tracing-subscriber",
  "tracing-tracy",
@@ -946,9 +960,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1019,39 +1033,15 @@ dependencies = [
 [[package]]
 name = "tokio-uring"
 version = "0.5.0"
-source = "git+https://github.com/kaimast/tokio-uring.git#0c8fd8acb3a9df9302bf45bab8dec8302aa0f132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "748482e3e13584a34664a710168ad5068e8cb1d968aa4ffa887e83ca6dd27967"
 dependencies = [
- "bytes",
  "futures-util",
  "io-uring",
  "libc",
- "memmap2",
  "slab",
  "socket2 0.4.10",
  "tokio",
- "tokio-uring-macros",
-]
-
-[[package]]
-name = "tokio-uring-executor"
-version = "0.1.0"
-source = "git+https://github.com/kaimast/tokio-uring-executor.git#9f999ed52803a86ae4d3a3a21afef91232323bec"
-dependencies = [
- "executor-macros",
- "log",
- "rand",
- "tokio",
- "tokio-uring",
-]
-
-[[package]]
-name = "tokio-uring-macros"
-version = "0.1.0"
-source = "git+https://github.com/kaimast/tokio-uring.git#0c8fd8acb3a9df9302bf45bab8dec8302aa0f132"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsm"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kai Mast <kai@kaimast.com>"]
 edition = "2021"
 repository = "https://github.com/kaimast/lsm-rs"
@@ -23,9 +23,8 @@ cfg-if = "1"
 tracing = { version="0.1", default-features=false, features=["attributes"] }
 csv = "1"
 tokio-condvar = { version="0.3", features=["parking_lot"] }
-#tokio-uring = { version="0.4", optional=true }
-tokio-uring = { git="https://github.com/kaimast/tokio-uring.git", features=["mmap"], optional=true }
-tokio-uring-executor = { git="https://github.com/kaimast/tokio-uring-executor.git", optional=true }
+tokio-uring = { version="0.5", optional=true }
+tokio-uring-executor = { package="kioto-uring-executor", version="0.1", optional=true }
 bloomfilter = { version="1", optional=true }
 
 [dependencies.tokio]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Kai Mast
+Copyright (c) 2024 Kai Mast
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,9 @@
-UNRELEASED:
+0.4:
     - Move sync API into a separate lsm-sync crate
     - Removed KvTrait. The crate now only accept and returns bytes
     - Get operations now return a reference to the data without copying
     - Leverage zerocopy wherever possible to reduce serialization cost
+    - Update tokio-uring and kioto-uring-executor dependencies
 
 0.3:
     - Write-Ahead logging moved to a dedicated thread (or async task)

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ This implementation does *not* aim to reimplement LevelDB. The major differences
 * *io_uring-support*: For async file system access on Linux. Optional and still considered experimental.
 * *Bloom filters* for faster lookups
 
-## Latest Version
-The version on crates.io is quite outdated as it does not allow to publish crates with git dependencies.
-It is recommended to use the `main` git branch instead.
-
 ## Supported Platfomrs and Architectures
 Currently, the code is only tested with Linux on x86 machines, but it should run on most systems supported by the Rust compiler.
 

--- a/src/data_blocks/mod.rs
+++ b/src/data_blocks/mod.rs
@@ -204,7 +204,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[cfg(feature = "async-io")]
-    use tokio_uring::test as async_test;
+    use tokio_uring_executor::test as async_test;
 
     #[cfg(not(feature = "async-io"))]
     use tokio::test as async_test;

--- a/src/sorted_table/tests.rs
+++ b/src/sorted_table/tests.rs
@@ -5,7 +5,7 @@ use crate::manifest::Manifest;
 use tempfile::tempdir;
 
 #[cfg(feature = "async-io")]
-use tokio_uring::test as async_test;
+use tokio_uring_executor::test as async_test;
 
 #[cfg(not(feature = "async-io"))]
 use tokio::test as async_test;


### PR DESCRIPTION
Moves to using tokio-uring and kioto-uring-executor from crates.io, so that we can publish the crate normally again.